### PR TITLE
[phpunit] Sticks to phpunit 4.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "require-dev": {
         "raveren/kint": "1.*",
-        "phpunit/phpunit": "^4.8.0"
+        "phpunit/phpunit": "4.8"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Build is [failing on master for PHP 7](https://travis-ci.org/razorpay/razorpay-php/builds/254445815). This is because Travis is using latest PHPUnit, v6.

PHPUnit [dropped support for PHP 5.3-5.5 in v5.0](https://github.com/sebastianbergmann/phpunit/wiki/Release-Announcement-for-PHPUnit-5.0.0#dropping-support-for-php-53-php-54-and-php-55), and [dropped PHP 5.6.0 in v6](https://github.com/sebastianbergmann/phpunit/wiki/Release-Announcement-for-PHPUnit-6.0.0#dropping-support-for-php-56).

We're sticking to 4.8 so we can continue supporting the older versions of PHP.