### PR TITLE
Add ability to override default curl options (e.g. timeouts)

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -29,6 +29,11 @@ class Request
         'Razorpay-API'  =>  1
     );
 
+    public static $options = array(
+        'timeout' => 60,
+        'connect_timeout' => 60
+    );
+
     /**
      * Fires a request to the API
      * @param  string   $method HTTP Verb
@@ -45,11 +50,10 @@ class Request
 
         $hooks->register('curl.before_send', array($this, 'setCurlSslOpts'));
 
-        $options = array(
+        $options = array_merge(static::$options, array(
             'auth' => array(Api::getKey(), Api::getSecret()),
-            'hook' => $hooks,
-            'timeout' => 60,
-        );
+            'hook' => $hooks
+        ));
 
         $headers = $this->getRequestHeaders();
 


### PR DESCRIPTION
Adding static variable to allow overriding of some curl defaults like timeouts.

Added `connect_timeout` to up the default _connection_ timeout from 10secs to 60secs. This may help with timeouts in https://github.com/razorpay/razorpay-php/issues/124