### PR TITLE
added json type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Changelog for Razorpay-PHP SDK. Follows [keepachangelog.com](https://keepachange
 
 ## Unreleased
 
+## [2.8.7] - 2023-09-11
+Chore: Changed Content-Type of `order create` APIs from application/x-www-form-urlencoded to application/json
+
+
 ## [2.8.6] - 2023-06-16
 [#348](https://github.com/razorpay/razorpay-php/pull/348) [`68b2028`](https://github.com/razorpay/razorpay-php/commit/68b2028bafda49af970a098d6d11aa8e5a575d40) feat: Added new API endpoints
 

--- a/src/Api.php
+++ b/src/Api.php
@@ -16,7 +16,7 @@ class Api
      */
     public static $appsDetails = array();
 
-    const VERSION = '2.8.6';
+    const VERSION = '2.8.7';
 
     /**
      * @param string $key


### PR DESCRIPTION
## Added

### [2.8.7]

Chore: Added Content-Type `application/json` for `order create` API from default `application/x-www-form-urlencoded` 