### PR TITLE
Replaced get_class() with static::class to ensure compatibility with php 8+

### DIFF
--- a/src/Errors/ErrorCode.php
+++ b/src/Errors/ErrorCode.php
@@ -8,10 +8,14 @@ class ErrorCode
     const SERVER_ERROR                      = 'SERVER_ERROR';
     const GATEWAY_ERROR                     = 'GATEWAY_ERROR';
 
-    public static function exists($code)
+    /**
+     * @param string $code
+     * @return bool
+     */
+    public static function exists(string $code): bool
     {
         $code = strtoupper($code);
 
-        return defined(get_class() . '::' . $code);
+        return defined(static::class. '::' . $code);
     }
 }


### PR DESCRIPTION

Explicitly passing ```null``` as the object to ```get_class()``` is no longer allowed as of PHP 7.2.0 and emits an **E_WARNING** . As of PHP 8.0.0, a **TypeError**  is emitted when ```null``` is used, as per [php.net](https://www.php.net/manual/en/function.get-class.php).