### PR TITLE
fix: updated refund relative url to match current api

### DIFF
--- a/src/Payment.php
+++ b/src/Payment.php
@@ -45,11 +45,9 @@ class Payment extends Entity
      */
     public function refund($attributes = array())
     {
-        $refund = new Refund;
+        $relativeUrl = $this->getEntityUrl() . $this->id . '/refund';
 
-        $attributes = array_merge($attributes, array('payment_id' => $this->id));
-
-        return $refund->create($attributes);
+        return $this->request('POST', $relativeUrl, $attributes);
     }
 
     /**


### PR DESCRIPTION
 The refunds were failing as reported on issues section, 
RazorPay current refund API doc [https://razorpay.com/docs/api/refunds/create-normal/]

states clearly that the relative url should be "/payments/:id/refund" and not "/refunds"

so modified refund function on Payment.php line 46 with new implementation