### PR TITLE
bump version v2.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 Changelog for Razorpay-PHP SDK. Follows [keepachangelog.com](https://keepachangelog.com/en/1.0.0/) for formatting.
- 
+
 ## Unreleased
 
 ## [2.9.2] - 2025-08-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Change Log
 
 Changelog for Razorpay-PHP SDK. Follows [keepachangelog.com](https://keepachangelog.com/en/1.0.0/) for formatting.
-
+ 
 ## Unreleased
+
+## [2.9.2] - 2025-08-05
+- fix: Content-Type header leakage in `Order::create()` where setting application/json globally caused subsequent API calls.
+- fix: Replaced deprecated `get_class()` usage in the `ErrorCode::exists()` method with the __CLASS__ constant to resolve PHP deprecation warnings.
 
 ## [2.9.1] - 2025-03-20
 feat: Added support for access token based authentication mechanism

--- a/src/Api.php
+++ b/src/Api.php
@@ -18,7 +18,7 @@ class Api
      */
     public static $appsDetails = array();
 
-    const VERSION = '2.9.1';
+    const VERSION = '2.9.2';
 
     /**
      * @param string $key


### PR DESCRIPTION
## [2.9.2] - 2025-08-05
- fix: Content-Type header leakage in `Order::create()` where setting application/json globally caused subsequent API calls.
- fix: Replaced deprecated `get_class()` usage in the `ErrorCode::exists()` method with the __CLASS__ constant to resolve PHP deprecation warnings.
