### PR TITLE
chore: upgrade to PHP 8.2+ and update dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,29 +9,33 @@ on:
     branches:
       - master
 jobs:
-  run:
+  test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: ['8.1', '8.2', '8.3', '8.4']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up php 8.0
+        uses: actions/checkout@v4
+      - name: Set up PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: ${{ matrix.php-version }}
+          coverage: xdebug
       - name: 'Create env file'
         run: |
           touch ${{ github.workspace }}/tests/.env
           echo RAZORPAY_API_KEY=${{ secrets.RAZORPAY_API_KEY }} >> ${{ github.workspace }}/tests/.env
           echo RAZORPAY_API_SECRET=${{ secrets.RAZORPAY_API_SECRET }} >> ${{ github.workspace }}/tests/.env
-          cat ${{ github.workspace }}/tests/.env          
       - name: Install dependencies
         run: composer self-update && composer install && composer require vlucas/phpdotenv && composer dump-autoload
       - name: Run tests and collect coverage
-        run: vendor/bin/phpunit ./tests/CoverageTest.php --coverage-clover coverage.xml .
+        run: vendor/bin/phpunit ./tests/CoverageTest.php --coverage-clover coverage.xml
         env:
            RAZORPAY_API_KEY: ${{ secrets.RAZORPAY_API_KEY }}
            RAZORPAY_API_SECRET: ${{ secrets.RAZORPAY_API_SECRET }}
            RAZORPAY_PARTNER_API_KEY: ${{ secrets.RAZORPAY_PARTNER_API_KEY }}
            RAZORPAY_PARTNER_API_SECRET: ${{ secrets.RAZORPAY_PARTNER_API_SECRET }}
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        if: matrix.php-version == '8.4'
+        uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['8.1', '8.2', '8.3', '8.4']
+        php-version: ['8.2', '8.3', '8.4', '8.5']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -37,5 +37,5 @@ jobs:
            RAZORPAY_PARTNER_API_KEY: ${{ secrets.RAZORPAY_PARTNER_API_KEY }}
            RAZORPAY_PARTNER_API_SECRET: ${{ secrets.RAZORPAY_PARTNER_API_SECRET }}
       - name: Upload coverage to Codecov
-        if: matrix.php-version == '8.4'
+        if: matrix.php-version == '8.5'
         uses: codecov/codecov-action@v4

--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,13 @@
     "homepage": "https://docs.razorpay.com",
     "license": "MIT",
     "require": {
-        "php": ">=7.3",
+        "php": ">=8.1",
         "rmccue/requests": "^2.0",
         "ext-json": "*"
     },
     "require-dev": {
-        "raveren/kint": "1.*",
-        "phpunit/phpunit": "^9"
+        "raveren/kint": "^5.0",
+        "phpunit/phpunit": "^10.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,12 @@
     "homepage": "https://docs.razorpay.com",
     "license": "MIT",
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "rmccue/requests": "^2.0",
         "ext-json": "*"
     },
     "require-dev": {
-        "raveren/kint": "^5.0",
+        "kint-php/kint": "^5.0",
         "phpunit/phpunit": "^10.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require-dev": {
         "kint-php/kint": "^5.0",
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^9.6"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- Upgrade minimum PHP version from 7.3 to 8.2 (8.1 EOL Dec 2025)
- Update GitHub Actions from v2 to v4
- Add CI matrix testing for PHP 8.2, 8.3, 8.4, 8.5
- Update dependencies:
  - PHPUnit ^9 → ^9.6 (staying on 9.x for test compatibility)
  - raveren/kint 1.* → kint-php/kint ^5.0 (correct package name)

## Test plan
- [ ] CI passes on PHP 8.2, 8.3, 8.4, 8.5
- [ ] Existing tests continue to pass
- [ ] Verify no breaking API changes

🤖 Generated with [Claude Code](https://claude.ai/code)