### PR TITLE
Fix: guard REQUESTS_SILENCE_PSR0_DEPRECATIONS define to prevent constant collision

### DIFF
--- a/Deprecated.php
+++ b/Deprecated.php
@@ -11,7 +11,7 @@
  *
  * @deprecated 2.0.4 Use the PSR-4 class names instead.
  */
-define("REQUESTS_SILENCE_PSR0_DEPRECATIONS",true);
+if (!defined("REQUESTS_SILENCE_PSR0_DEPRECATIONS")) define("REQUESTS_SILENCE_PSR0_DEPRECATIONS", true);
 
 if (class_exists('WpOrg\Requests\Autoload') === false) {
 	require_once __DIR__. 'libs/Requests-2.0.4/src/Autoload.php';


### PR DESCRIPTION
## Problem

`Deprecated.php` defines `REQUESTS_SILENCE_PSR0_DEPRECATIONS` unconditionally:

```php
define("REQUESTS_SILENCE_PSR0_DEPRECATIONS", true);
```

If another package or the host environment has already defined this constant before the Composer autoloader runs, PHP throws a fatal error:

```
PHP Fatal error: Constant REQUESTS_SILENCE_PSR0_DEPRECATIONS already defined
```

A common case is WordPress, which defines this constant in its bundled Requests library before any plugin's autoloader is executed.

## Fix

Wrap the `define()` with a `!defined()` guard — the same pattern already used in `Razorpay.php` in this package:

```php
if (!defined("REQUESTS_SILENCE_PSR0_DEPRECATIONS")) define("REQUESTS_SILENCE_PSR0_DEPRECATIONS", true);
```

Closes #415