### PR TITLE
Fix double slash in customer eligibility URLs (customers//eligibility)

### DIFF
--- a/src/Customer.php
+++ b/src/Customer.php
@@ -54,14 +54,14 @@ class Customer extends Entity
 
     public function requestEligibilityCheck($attributes = array())
     {
-        $entityUrl = $this->getEntityUrl(). '/eligibility';
+        $entityUrl = $this->getEntityUrl(). 'eligibility';
 
         return $this->request('POST', $entityUrl, $attributes);
     }
 
     public function fetchEligibility($id)
     {
-        $entityUrl = $this->getEntityUrl(). '/eligibility/'. $id;
+        $entityUrl = $this->getEntityUrl(). 'eligibility/'. $id;
 
         return $this->request('GET', $entityUrl);
     }


### PR DESCRIPTION
## Summary

`Customer::getEntityUrl()` returns `customers/` (trailing slash), but the two eligibility methods append `/eligibility` with a **leading** slash, producing a double slash:

```php
$this->getEntityUrl() . '/eligibility'       // => customers//eligibility
$this->getEntityUrl() . '/eligibility/' . $id // => customers//eligibility/{id}
```

Every other method in the SDK builds sub-resource paths without a leading slash (e.g. `getEntityUrl() . $this->id . '/bank_account'`), and all sibling SDKs target the single-slash path:

| SDK | URL |
|---|---|
| razorpay-node | `/customers/eligibility` |
| razorpay-python | `customers/eligibility` |
| razorpay-go | `/v1/customers/eligibility` |

Only razorpay-php emits `customers//eligibility`, which URL routers may treat as a distinct (invalid) path.

## Fix

Drop the leading slash so the URLs become `customers/eligibility` and `customers/eligibility/{id}`, matching the other methods and SDKs.

## Verification

The change is a deterministic string concatenation (`customers/` + `eligibility` = `customers/eligibility`) and is cross-checked against the node/python/go SDKs above. Note: this repo's test suite makes live Razorpay API calls (requires real keys), so I was unable to run it locally — happy to adjust if you'd like it validated differently.
