### PR TITLE
Guard REQUESTS_SILENCE_PSR0_DEPRECATIONS define in Deprecated.php

### DIFF
--- a/Deprecated.php
+++ b/Deprecated.php
@@ -11,7 +11,10 @@
  *
  * @deprecated 2.0.4 Use the PSR-4 class names instead.
  */
-define("REQUESTS_SILENCE_PSR0_DEPRECATIONS",true);
+if (!defined('REQUESTS_SILENCE_PSR0_DEPRECATIONS'))
+{
+    define('REQUESTS_SILENCE_PSR0_DEPRECATIONS', true);
+}
 
 if (class_exists('WpOrg\Requests\Autoload') === false) {
 	require_once __DIR__. 'libs/Requests-2.0.4/src/Autoload.php';


### PR DESCRIPTION
`Deprecated.php` defines `REQUESTS_SILENCE_PSR0_DEPRECATIONS` unconditionally. When the host application or another package (for example WordPress core, which ships this constant in its bundled Requests library) has already defined it before this file loads, PHP raises `Fatal error: Constant REQUESTS_SILENCE_PSR0_DEPRECATIONS already defined`. `Razorpay.php` in this same package already wraps the define in an `if (!defined(...))` guard, so this just brings `Deprecated.php` in line with it. Fixes #415.

## Note :- Please follow the below points while attaching test cases document link below:
   ### - If label `Tested` is added then test cases document URL is mandatory.
   ### - Link added should be a valid URL and accessible throughout the org.
   ### - If the branch name contains hotfix / revert by default the BVT workflow check will pass.

| Test Case Document URL                        |
|-----------------------------------------------|
| Please paste test case document link here.... |
