### PR TITLE
chore: add servicetree.yaml manifest

### DIFF
--- a/servicetree.yaml
+++ b/servicetree.yaml
@@ -1,0 +1,38 @@
+service: razorpay-php  # required, canonical slug — immutable once registered
+displayName: "Razorpay PHP SDK"  # README: 'Official PHP library for Razorpay API' — distributed on Packagist as razorpay/razorpay
+description: "Official PHP client library for the Razorpay API, distributed via Composer/Packagist, that merchants use to integrate payments, refunds, orders and other Razorpay APIs into PHP applications."  # repo README (composer require razorpay/razorpay:2.*)
+type: library  # a Composer/Packagist client SDK — merchant-side dependency, no server deployment · retype after the serviceTypes enum widens: sdk
+tier: T1  # official merchant-integration SDK on the payment path: bugs or a bad release affect every PHP merchant's payment integration, though upgrades are merchant-controlled
+lifecycle: live  # actively maintained official SDK (last push 2026-08-12, versioned releases on Packagist)
+aliases: ["razorpay-php-sdk"]  # commonly referred to as the Razorpay PHP SDK; Packagist package razorpay/razorpay
+
+domain: razorpay1/partnerships  # family razorpay1 from miss_seed l1 (BU 'SME Payments', team 'Partnerships', POD 'PG (Plugins, Checkout)'); area partnerships reuses the existing razorpay1/partnerships slug — public SDKs/plugins sit with the Partnerships team
+
+owner:
+  team:  # required, owning team slug — TO FILL: this repo has no CODEOWNERS file, .github/repo_owners.json carries no team slug, and the GitHub repository-teams API is not readable with the current token; ask the POD lead for the owning GitHub team
+  em:  # name | @slack | email — TO FILL: DevRev runnable owner not found in SuccessFactors
+  org_group:  # SuccessFactors group of the EM — TO FILL: the declared owner has no SuccessFactors record, so the org tree cannot be resolved; ask the POD lead
+  org_sub_group:  # SuccessFactors sub-group of the EM — TO FILL: the declared owner has no SuccessFactors record; ask the POD lead
+  org_pod:  # SuccessFactors pod of the EM — TO FILL: the declared owner has no SuccessFactors record; ask the POD lead
+  pm:  # TO FILL: not derivable; ask the Partnerships POD lead (shobhit.jain)
+  overrides: []  # optional, region-scoped owner overrides — TO FILL only if some region is owned by a different team; each entry is a "region" code plus the owning "team" slug
+
+links:
+  repo: "https://github.com/razorpay/razorpay-php"  # canonical GitHub repo URL
+  alerts_repo:  # this service's alert rules in razorpay/alert-rules — TO FILL: no matching ruleset found; add one in razorpay/alert-rules, then link the file here
+  slos:  # SLO definitions — TO FILL: no slo.yaml at this repo root and no sloth ruleset for it under razorpay/alert-rules/slo/prod (the two places SLOs are defined today); add one there and link it here
+  slack_channel:  # TO FILL: no slack_candidates harvested and the Slack channel index is unavailable in this environment; ask the Partnerships POD lead — a #plugins or #sdk channel likely exists
+  zenduty_policy:  # Zenduty policy/service name used for paging — TO FILL: the service-to-policy mapping is not in DevRev or alert-rules for this service; it lives in the external Zenduty policies sheet
+  escalation_l1:  # service EM — TO FILL: no owner could be resolved for this service
+  escalation_l2:  # EM's manager — TO FILL: the EM has no SuccessFactors record, so no manager chain is available
+  escalation_l3:  # manager's manager — TO FILL: the EM has no SuccessFactors record, so no manager chain is available
+  oncall_handle:  # Slack/PagerDuty oncall handle or usergroup — TO FILL: not set on the DevRev runnable
+  runbook:  # link to the incident runbook — TO FILL: no runbook directory for this service in razorpay/rzp-oncall-agent; add one or link the Google Doc / alpha.razorpay.com page
+  api_docs: "https://razorpay.com/docs/payments"  # README points to docs.razorpay.com/docs/payments for the API this SDK wraps
+  dashboard:  # TO FILL: not applicable — client SDK with no server runtime
+  logs_and_traces: "https://razorpay-prod.app.coralogix.in/#/query-new/archive-logs"  # org-standard prod Coralogix — filter subsystem "razorpay-php"
+  strategy_okr:  # TO FILL: link the FY strategy doc for the owning group.
+  risk_assessment:  # TO FILL: no .agents/skills/risk-assessment in this repo; add the per-repo risk-assessment skill
+  regions:  # per-region links; one block per geography this service is deployed in
+
+dependencies: []  # optional, declared service dependencies — TO FILL: shape: - service: <slug> for internal deps, - vendor: <name> for external (gateways, banks)


### PR DESCRIPTION
Adds the Service Tree manifest (`servicetree.yaml`) to the repo root.

This manifest declares service ownership, tier, domain, and links for the Service Tree registry. Fields not yet sourced are left blank with inline comments.

Part of the Service Tree rollout.

Generated with Claude Code